### PR TITLE
Improve signup flow with profile defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,74 +1,88 @@
 # BookReviewHub
 
-Here’s a clean, professional `README.md` template that includes all the requested sections—ready for your customization:
+BookReviewHub is a full-stack web application for browsing books and sharing reviews. The backend is built with **Spring Boot** and the frontend uses **React** with **Tailwind CSS**.
 
----
+## Features
+- User registration and authentication
+- Browse and search a catalog of books
+- Write, edit and delete reviews
+- User profiles with display name and avatar
+- Admin dashboard for managing books and reviews
 
-````markdown
-# Project Title
+## Getting Started
 
-## Description
+### Prerequisites
+- [Node.js](https://nodejs.org)
+- Java 17+ and [Maven](https://maven.apache.org)
 
-[Insert a brief description of the project here. Explain what the system does, its core features, and its primary purpose. Mention technologies used if relevant.]
+### Installation
+1. Clone the repository.
+2. Install front-end dependencies:
+   ```bash
+   cd frontend
+   npm install
+   ```
+3. Start the backend server:
+   ```bash
+   cd ../backend
+   ./mvnw spring-boot:run
+   ```
+4. In another terminal, start the React development server:
+   ```bash
+   cd ../frontend
+   npm run dev
+   ```
 
----
+You can also run both servers together from the project root with:
+```bash
+npm run dev
+```
+
+## Screenshots
+Place screenshots of the website in this section.
+
+![Homepage](./path/to/homepage.png)
+![Book page](./path/to/book-page.png)
 
 ## Pseudocode
 
 ```plaintext
-[Insert your pseudocode here. This can describe the main logic or workflow, e.g., user registration, review submission, data retrieval, etc.]
-
-Example:
 IF user submits review
     FETCH book by ID
     ADD review to book.reviews
-    CALCULATE new average rating
-    UPDATE book rating
+    RECALCULATE book rating
+    UPDATE book
 END IF
 ```
-````
-
----
 
 ## Entity-Relationship Diagram (ERD)
 
-\[Insert a brief explanation of the ERD here. Describe how entities like `User`, `Book`, `Review` relate to each other.]
+The application is centred around three main entities: **User**, **Book**, and **Review**.
 
 ![ERD Diagram Placeholder](./path/to/erd-image.png)
-
-Example:
 
 - **User** has many **Reviews**
 - **Book** has many **Reviews**
 - **Review** belongs to both **User** and **Book**
 
----
-
 ## User Stories
 
-- **\[User Story 1]**
-  _As a user, I want to register and log in so that I can access personalized features._
+- **[US1]** _As a visitor, I can sign up with a username and profile picture so that others can recognise me._
+- **[US2]** _As a reader, I want to browse books and see their ratings so that I can choose what to read._
+- **[US3]** _As a logged-in user, I can post reviews anonymously or with my profile._
+- **[US4]** _As an admin, I can manage books and moderate reviews._
 
-- **\[User Story 2]**
-  _As a user, I want to browse books and see their average rating so that I can choose what to read._
+## Future Improvements
 
-- **\[User Story 3]**
-  _As a user, I want to write and update reviews for books so that I can share my opinion._
+- Add automated tests for authentication and profile updates
+- Validate uploaded profile images server-side
+- Store user-uploaded images in dedicated cloud storage
 
-- **\[User Story 4]**
-  _As an admin, I want to manage books in the database so that I can keep the catalog updated._
+## Maintainer
+This project is maintained by [**Sabretooth2438**](https://github.com/Sabretooth2438).
 
-(Add more stories as needed.)
-
----
-
-## More Information
-
-For additional details and to explore the project, visit the [project website](https://your-project-url.com).
+<img src="https://github.com/Sabretooth2438.png" width="100" alt="Sabretooth2438 avatar" />
 
 ---
 
-```
-
-Let me know if you'd like this auto-filled for your current BookReviewHub project (including ERD, user stories, and logic).
-```
+Feel free to open issues or submit pull requests to contribute.

--- a/backend/src/main/java/com/bookreviewhub/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/bookreviewhub/backend/controller/AuthController.java
@@ -30,7 +30,7 @@ public class AuthController {
 
   @PostMapping("/signup")
   public ResponseEntity<?> signup(@RequestBody Signup dto) {
-    users.register(dto.email, dto.password, Role.USER);
+    users.register(dto.email, dto.password, Role.USER, dto.username, dto.avatarUrl);
     return ResponseEntity.ok(Map.of("msg", "registered"));
   }
 
@@ -65,6 +65,28 @@ public class AuthController {
     return ResponseEntity.ok(Map.of("msg", "password updated"));
   }
 
+  // ----- profile -----
+
+  @GetMapping("/profile")
+  public ResponseEntity<?> profile(Authentication a) {
+    if (a == null)
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+    User u = users.findByEmail(a.getName());
+    if (u == null)
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+    return ResponseEntity.ok(u);
+  }
+
+  @PutMapping("/profile")
+  public ResponseEntity<?> updateProfile(@RequestBody Profile dto, Authentication a) {
+    if (a == null)
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+    users.updateProfile(a.getName(), dto.username, dto.avatarUrl);
+    return ResponseEntity.ok(Map.of("msg", "profile updated"));
+  }
+
   // Data Transfer Objects (DTOs) for signup and login
 
   @Data
@@ -74,6 +96,8 @@ public class AuthController {
     String email;
     @NotBlank
     String password;
+    String username;
+    String avatarUrl;
   }
 
   @Data
@@ -83,6 +107,12 @@ public class AuthController {
     String email;
     @NotBlank
     String password;
+  }
+
+  @Data
+  static class Profile {
+    String username;
+    String avatarUrl;
   }
 
   // Password reset DTO

--- a/backend/src/main/java/com/bookreviewhub/backend/controller/ReviewController.java
+++ b/backend/src/main/java/com/bookreviewhub/backend/controller/ReviewController.java
@@ -33,6 +33,10 @@ public class ReviewController {
       Authentication a) throws Exception {
     r.setBookId(bookId);
     r.setCreatedBy(a.getName());
+    if (r.isAnonymous()) {
+      r.setUsername("Anonymous");
+      r.setAvatarUrl("");
+    }
     return svc.create(r);
   }
 
@@ -45,6 +49,10 @@ public class ReviewController {
       Authentication a) throws Exception {
     r.setId(id);
     r.setCreatedBy(a.getName());
+    if (r.isAnonymous()) {
+      r.setUsername("Anonymous");
+      r.setAvatarUrl("");
+    }
     return svc.update(r);
   }
 

--- a/backend/src/main/java/com/bookreviewhub/backend/model/Review.java
+++ b/backend/src/main/java/com/bookreviewhub/backend/model/Review.java
@@ -11,4 +11,7 @@ public class Review {
   private String content;
   private double rating;
   private String createdBy;
+  private String username;
+  private String avatarUrl;
+  private boolean anonymous;
 }

--- a/backend/src/main/java/com/bookreviewhub/backend/model/User.java
+++ b/backend/src/main/java/com/bookreviewhub/backend/model/User.java
@@ -11,4 +11,6 @@ public class User {
   private String email;
   private String password;
   private Role role;
+  private String username;
+  private String avatarUrl;
 }

--- a/backend/src/main/java/com/bookreviewhub/backend/seed/RandomReviewsSeeder.java
+++ b/backend/src/main/java/com/bookreviewhub/backend/seed/RandomReviewsSeeder.java
@@ -32,7 +32,7 @@ public class RandomReviewsSeeder {
   @Bean
   ApplicationRunner run() {
     return args -> {
-      if (!reviews.ofBook("dummy").isEmpty()) {
+      if (reviews.hasAnyReview()) {
         log.info("💬  Review seeding skipped – collection already populated.");
         return;
       }
@@ -47,7 +47,10 @@ public class RandomReviewsSeeder {
               b.getId(),
               COMMENTS[rnd.nextInt(COMMENTS.length)],
               rnd.nextInt(6),
-              "seed@bot");
+              "seed@bot",
+              "Seed Bot",
+              "",
+              false);
 
           reviews.create(r);
           total++;

--- a/backend/src/main/java/com/bookreviewhub/backend/service/ReviewService.java
+++ b/backend/src/main/java/com/bookreviewhub/backend/service/ReviewService.java
@@ -44,6 +44,15 @@ public class ReviewService {
     }
   }
 
+  public boolean hasAnyReview() {
+    try {
+      return !db().collection(COL_REVIEWS).limit(1).get().get().isEmpty();
+    } catch (InterruptedException | ExecutionException e) {
+      Thread.currentThread().interrupt();
+      return false;
+    }
+  }
+
   // Updated CRUD operations
 
   public Book create(Review r) throws Exception {

--- a/backend/src/main/java/com/bookreviewhub/backend/service/UserService.java
+++ b/backend/src/main/java/com/bookreviewhub/backend/service/UserService.java
@@ -39,9 +39,10 @@ public class UserService {
     }
   }
 
-  public User register(String email, String rawPw, Role role) {
+  public User register(String email, String rawPw, Role role, String username, String avatarUrl) {
     String hash = encoder.encode(rawPw);
-    User u = new User(UUID.randomUUID().toString(), email, hash, role);
+    String display = (username == null || username.isBlank()) ? email : username;
+    User u = new User(UUID.randomUUID().toString(), email, hash, role, display, avatarUrl);
     db().collection(COL).document(u.getId()).set(u);
     return u;
   }
@@ -51,6 +52,15 @@ public class UserService {
     if (u == null)
       throw new RuntimeException("No user");
     u.setPassword(encoder.encode(raw));
+    db().collection(COL).document(u.getId()).set(u);
+  }
+
+  public void updateProfile(String email, String username, String avatarUrl) {
+    User u = findByEmail(email);
+    if (u == null)
+      throw new RuntimeException("No user");
+    u.setUsername(username);
+    u.setAvatarUrl(avatarUrl);
     db().collection(COL).document(u.getId()).set(u);
   }
 

--- a/frontend/src/pages/BookDetails.jsx
+++ b/frontend/src/pages/BookDetails.jsx
@@ -56,6 +56,9 @@ const BookDetails = () => {
 
   const [content, setContent] = useState('')
   const [rating, setRating] = useState(0)
+  const [username, setUsername] = useState('')
+  const [avatarUrl, setAvatarUrl] = useState('')
+  const [anonymous, setAnonymous] = useState(false)
   const [editR, setEditR] = useState(null)
   const [delId, setDelId] = useState(null)
 
@@ -91,6 +94,26 @@ const BookDetails = () => {
 
           {token && (
             <div className="my-6 space-y-2">
+              <input
+                className="w-full border rounded p-2 bg-white dark:bg-gray-800"
+                placeholder="Display name"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+              />
+              <input
+                className="w-full border rounded p-2 bg-white dark:bg-gray-800"
+                placeholder="Avatar URL"
+                value={avatarUrl}
+                onChange={(e) => setAvatarUrl(e.target.value)}
+              />
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={anonymous}
+                  onChange={(e) => setAnonymous(e.target.checked)}
+                />
+                Post anonymously
+              </label>
               <textarea
                 className="w-full border rounded p-2 bg-white dark:bg-gray-800"
                 placeholder="Write a review…"
@@ -104,9 +127,18 @@ const BookDetails = () => {
                 </div>
                 <Button
                   onClick={() => {
-                    make.mutate({ content, rating: Number(rating) })
+                    make.mutate({
+                      content,
+                      rating: Number(rating),
+                      username,
+                      avatarUrl,
+                      anonymous,
+                    })
                     setContent('')
                     setRating(0)
+                    setUsername('')
+                    setAvatarUrl('')
+                    setAnonymous(false)
                   }}
                 >
                   Submit
@@ -133,7 +165,18 @@ const BookDetails = () => {
                       </span>
                     </div>
                     <p>{r.content}</p>
-                    <p className="text-xs text-gray-500">by {r.createdBy}</p>
+                    <div className="flex items-center gap-2 text-xs text-gray-500">
+                      {!r.anonymous && r.avatarUrl && (
+                        <img
+                          src={r.avatarUrl}
+                          alt={r.username}
+                          className="w-6 h-6 rounded-full"
+                        />
+                      )}
+                      <span>
+                        by {r.anonymous ? 'Anonymous' : r.username || r.createdBy}
+                      </span>
+                    </div>
                   </div>
 
                   {owner && (
@@ -164,6 +207,26 @@ const BookDetails = () => {
               value={editR.content}
               onChange={(e) => setEditR({ ...editR, content: e.target.value })}
             />
+            <Input
+              value={editR.username || ''}
+              onChange={(e) => setEditR({ ...editR, username: e.target.value })}
+              placeholder="Display name"
+            />
+            <Input
+              value={editR.avatarUrl || ''}
+              onChange={(e) => setEditR({ ...editR, avatarUrl: e.target.value })}
+              placeholder="Avatar URL"
+            />
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={editR.anonymous || false}
+                onChange={(e) =>
+                  setEditR({ ...editR, anonymous: e.target.checked })
+                }
+              />
+              Post anonymously
+            </label>
             <div className="flex items-center gap-2">
               <StarRating
                 value={editR.rating}

--- a/frontend/src/pages/Dashboard/BooksTable.jsx
+++ b/frontend/src/pages/Dashboard/BooksTable.jsx
@@ -30,6 +30,14 @@ const BooksTable = () => {
   const [draft, setDraft] = useState(blank)
   const [delId, setDelId] = useState(null)
 
+  const handleFile = (e) => {
+    const file = e.target.files[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => setDraft({ ...draft, imageUrl: reader.result })
+    reader.readAsDataURL(file)
+  }
+
   /* mutations — rating stripped before sending on update */
   const save = useMutation({
     mutationFn: (b) =>
@@ -139,6 +147,7 @@ const BooksTable = () => {
             value={draft.imageUrl}
             onChange={(e) => setDraft({ ...draft, imageUrl: e.target.value })}
           />
+          <input type="file" onChange={handleFile} />
 
           {/* Rating field removed from the form */}
 

--- a/frontend/src/pages/Dashboard/ReviewsTable.jsx
+++ b/frontend/src/pages/Dashboard/ReviewsTable.jsx
@@ -100,7 +100,18 @@ const ReviewsTable = () => {
                 {bookMap[r.bookId] ?? 'Unknown Book'}
               </Link>
               <p>{r.content}</p>
-              <p className="text-xs text-gray-500">by {r.createdBy}</p>
+              <div className="flex items-center gap-2 text-xs text-gray-500">
+                {!r.anonymous && r.avatarUrl && (
+                  <img
+                    src={r.avatarUrl}
+                    alt={r.username}
+                    className="w-6 h-6 rounded-full"
+                  />
+                )}
+                <span>
+                  by {r.anonymous ? 'Anonymous' : r.username || r.createdBy}
+                </span>
+              </div>
             </div>
 
             <div className="space-x-2">
@@ -134,6 +145,26 @@ const ReviewsTable = () => {
               value={editR.content}
               onChange={(e) => setEditR({ ...editR, content: e.target.value })}
             />
+            <Input
+              value={editR.username || ''}
+              onChange={(e) => setEditR({ ...editR, username: e.target.value })}
+              placeholder="Display name"
+            />
+            <Input
+              value={editR.avatarUrl || ''}
+              onChange={(e) => setEditR({ ...editR, avatarUrl: e.target.value })}
+              placeholder="Avatar URL"
+            />
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={editR.anonymous || false}
+                onChange={(e) =>
+                  setEditR({ ...editR, anonymous: e.target.checked })
+                }
+              />
+              Post anonymously
+            </label>
             <Input
               type="number"
               value={editR.rating}

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -1,14 +1,59 @@
+import { useEffect, useState } from 'react'
 import Header from '../components/layout/Header'
 import ResetPw from '../components/ResetPw'
+import Input from '../components/Input'
+import Button from '../components/Button'
+import { fetchProfile, updateProfile } from '../services/auth'
 
-const Profile = () => (
-  <>
-    <Header />
-    <main className="p-6 max-w-md mx-auto">
-      <h1 className="text-2xl font-bold mb-6">Account settings</h1>
-      <ResetPw />
-    </main>
-  </>
-)
+const Profile = () => {
+  const [username, setUsername] = useState('')
+  const [avatarUrl, setAvatarUrl] = useState('')
+
+  useEffect(() => {
+    fetchProfile().then((res) => {
+      setUsername(res.data.username || '')
+      setAvatarUrl(res.data.avatarUrl || '')
+    })
+  }, [])
+
+  const handleFile = (e) => {
+    const file = e.target.files[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => setAvatarUrl(reader.result)
+    reader.readAsDataURL(file)
+  }
+
+  const submit = async (e) => {
+    e.preventDefault()
+    await updateProfile(username, avatarUrl)
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="p-6 max-w-md mx-auto space-y-6">
+        <h1 className="text-2xl font-bold">Account settings</h1>
+        <form onSubmit={submit} className="space-y-3">
+          <Input
+            placeholder="Display name"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+          <Input
+            placeholder="Avatar URL"
+            value={avatarUrl}
+            onChange={(e) => setAvatarUrl(e.target.value)}
+          />
+          <input type="file" onChange={handleFile} />
+          <Button type="submit" className="w-full">
+            Update profile
+          </Button>
+        </form>
+        <ResetPw />
+      </main>
+    </>
+  )
+}
 
 export default Profile

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -1,18 +1,38 @@
 import { useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
-import { signup } from '../services/auth'
+import { signup, login } from '../services/auth'
+import { useAuth } from '../auth/AuthProvider'
 import Input from '../components/Input'
 import Button from '../components/Button'
 
 const Signup = () => {
   const [email, setEmail] = useState('')
   const [password, setPw] = useState('')
+  const [pw2, setPw2] = useState('')
+  const [username, setUsername] = useState('')
+  const [avatarUrl, setAvatar] = useState('')
+  const { dispatch } = useAuth()
   const nav = useNavigate()
+
+  const handleFile = (e) => {
+    const file = e.target.files[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => setAvatar(reader.result)
+    reader.readAsDataURL(file)
+  }
 
   const submit = async (e) => {
     e.preventDefault()
-    await signup(email, password)
-    nav('/login')
+    if (password !== pw2) {
+      alert('Passwords do not match')
+      return
+    }
+    const uname = username || email
+    await signup(email, password, uname, avatarUrl)
+    const { data } = await login(email, password)
+    dispatch({ type: 'LOGIN', token: data.token })
+    nav('/profile')
   }
 
   return (
@@ -31,10 +51,27 @@ const Signup = () => {
           onChange={(e) => setEmail(e.target.value)}
         />
         <Input
+          placeholder="Display name"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <Input
+          placeholder="Avatar URL"
+          value={avatarUrl}
+          onChange={(e) => setAvatar(e.target.value)}
+        />
+        <input type="file" onChange={handleFile} />
+        <Input
           type="password"
           placeholder="Password"
           value={password}
           onChange={(e) => setPw(e.target.value)}
+        />
+        <Input
+          type="password"
+          placeholder="Repeat password"
+          value={pw2}
+          onChange={(e) => setPw2(e.target.value)}
         />
         <Button className="w-full">Create account</Button>
 

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -1,10 +1,15 @@
 import api from './axios'
 
-export const signup = (email, password) =>
-  api.post('/api/auth/signup', { email, password })
+export const signup = (email, password, username, avatarUrl) =>
+  api.post('/api/auth/signup', { email, password, username, avatarUrl })
 
 export const login = (email, password) =>
   api.post('/api/auth/login', { email, password })
 
 export const resetPassword = (oldPassword, newPassword) =>
   api.post('/api/auth/reset-password', { oldPassword, newPassword })
+
+export const fetchProfile = () => api.get('/api/auth/profile')
+
+export const updateProfile = (username, avatarUrl) =>
+  api.put('/api/auth/profile', { username, avatarUrl })

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -14,5 +14,5 @@ export default {
     },
   },
 
-  plugins: [aspect, require('@tailwindcss/aspect-ratio')],
+  plugins: [aspect],
 }


### PR DESCRIPTION
## Summary
- default username to email in `UserService`
- redirect new users to their profile and ensure password confirmation
- auto-login after signup
- list future improvements in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `sh ./backend/mvnw -q -DskipTests package` *(fails: could not resolve Spring dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685922dfef208325a79ae057bd9297be